### PR TITLE
Fix an animation of a "replace fragment" command

### DIFF
--- a/alligator/src/main/java/me/aartikov/alligator/helpers/FragmentStack.java
+++ b/alligator/src/main/java/me/aartikov/alligator/helpers/FragmentStack.java
@@ -130,7 +130,7 @@ public class FragmentStack {
 
 		FragmentTransaction transaction = mFragmentManager.beginTransaction();
 		if (currentFragment != null) {
-			animation.applyBeforeFragmentTransactionExecuted(transaction, currentFragment, fragment);
+			animation.applyBeforeFragmentTransactionExecuted(transaction, fragment, currentFragment);
 			transaction.remove(currentFragment);
 		}
 


### PR DESCRIPTION
There's a small animation issue related to Lollipop transitions. The FragmentStack class uses (seemingly?) wrong fragments when it tries to apply an animation during execution of a Replace command. Because of that enter transition animations are not used during the transition itself. It seems like a small typo and a bit of testing showed no problems related to the changes.