### PR TITLE
Add "fun" keyword to SAM interface listeners

### DIFF
--- a/alligator/src/main/java/me/aartikov/alligator/listeners/DialogShowingListener.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/listeners/DialogShowingListener.kt
@@ -5,7 +5,7 @@ import me.aartikov.alligator.Screen
 /**
  * Interface for listening of dialog showing.
  */
-interface DialogShowingListener {
+fun interface DialogShowingListener {
     /**
      * Is called when a dialog was shown.
      *

--- a/alligator/src/main/java/me/aartikov/alligator/listeners/NavigationErrorListener.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/listeners/NavigationErrorListener.kt
@@ -5,7 +5,7 @@ import me.aartikov.alligator.exceptions.NavigationException
 /**
  * Interface for navigation error handling.
  */
-interface NavigationErrorListener {
+fun interface NavigationErrorListener {
     /**
      * Is called when an error has occurred during [Command] execution.
      *

--- a/alligator/src/main/java/me/aartikov/alligator/listeners/ScreenResultListener.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/listeners/ScreenResultListener.kt
@@ -6,7 +6,7 @@ import me.aartikov.alligator.ScreenResult
 /**
  * Interface for screen result handling.
  */
-interface ScreenResultListener {
+fun interface ScreenResultListener {
     /**
      * Is called when a screen that can return a result has finished.
      *

--- a/alligator/src/main/java/me/aartikov/alligator/listeners/ScreenSwitchingListener.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/listeners/ScreenSwitchingListener.kt
@@ -5,7 +5,7 @@ import me.aartikov.alligator.Screen
 /**
  * Interface for listening of screen switching.
  */
-interface ScreenSwitchingListener {
+fun interface ScreenSwitchingListener {
     /**
      * Is called after a screen has been switched using [ScreenSwitcher].
      *

--- a/alligator/src/main/java/me/aartikov/alligator/listeners/TransitionListener.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/listeners/TransitionListener.kt
@@ -7,7 +7,7 @@ import me.aartikov.alligator.TransitionType
 /**
  * Interface for listening of screen transition.
  */
-interface TransitionListener {
+fun interface TransitionListener {
     /**
      * Is called when an usual screen transition (not screen switching and not dialog showing) has been executed.
      *


### PR DESCRIPTION
After updating to the latest version (4.4.0, migration to Kotlin), an error appeared in the listeners of lambdas in Kotlin code.

Here is the error:
![photo_2024-02-04 00 45 55](https://github.com/aartikov/Alligator/assets/6171938/54805d84-3721-4701-96ad-39f5f6ee2136)

After fix:
![photo_2024-02-04 00 45 58](https://github.com/aartikov/Alligator/assets/6171938/8e0396d0-4c6a-49d4-a846-ffb32c85fbfc)

With `object`:
![photo_2024-02-04 00 46 00](https://github.com/aartikov/Alligator/assets/6171938/f28787ca-79a9-4e53-a3a8-002f841259f3)

Java code:
![photo_2024-02-04 00 46 03](https://github.com/aartikov/Alligator/assets/6171938/5ea62fed-1f87-4ed9-b083-8736864b45e4)

