### PR TITLE
Improve the message of MissingScreenSwitcherException in SwitchToCommand

### DIFF
--- a/alligator/src/main/java/me/aartikov/alligator/commands/SwitchToCommand.kt
+++ b/alligator/src/main/java/me/aartikov/alligator/commands/SwitchToCommand.kt
@@ -17,7 +17,7 @@ class SwitchToCommand(
     @Throws(NavigationException::class)
     override fun execute(navigationContext: NavigationContext): Boolean {
         val screenSwitcher = navigationContext.screenSwitcher
-            ?: throw MissingScreenSwitcherException("ScreenSwitcher is not set.")
+            ?: throw MissingScreenSwitcherException("ScreenSwitcher is not set. The screen to switch: $mScreen")
         screenSwitcher.switchTo(mScreen, navigationContext.screenSwitchingListener, mAnimationData)
         return true
     }


### PR DESCRIPTION
It would be useful to know the screen that was switched to when the `MissingScreenSwitcherException` was thrown